### PR TITLE
Trim the string before comparing it to `""`

### DIFF
--- a/src/Lex.idr
+++ b/src/Lex.idr
@@ -60,7 +60,7 @@ endComplete (sc, oa, ca, a)
 ||| build brackets by folding lines / steps
 bracketBuilder : String → String
 bracketBuilder noBra =
-  let fnlns   = filter (/= "") (splitLines noBra)
+  let fnlns   = filter (\s => trim s /= "") (splitLines noBra)
       cStrs   = fnlns ⧺ [""] -- new line in the end
       cauto   = foldr1 foldProcessLines cStrs
       (_, cA) = foldl1 foldProcessRules $ (λ l → ([0, 0], l))


### PR DESCRIPTION
So that whitespace-only lines are discarded as well.


If you'd rather have it written `filter ((/= "") . trim) (...)`, I can send another PR.